### PR TITLE
Group membership evaluation

### DIFF
--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -29,7 +29,7 @@ LdapService.prototype.isAuthorized = function(username){
                 
                 self.ad.getGroupMembershipForUser(username, function(err, groups){
                     if(err) return reject(err);
-                     var authorized = _.intersection(_.map(groups, function(g) { return g.cn }), self.groups).length == self.groups.length;
+                     var authorized = _.intersection(_.map(groups, function(g) { return g.cn }), self.groups).length > 0;
                     cache.set(username, authorized);
                     resolve(authorized);
                 });


### PR DESCRIPTION
Changed group membership evaluation to OR instead of AND, when multiple groups are listed in the ldap configuration. Otherwise a user would need to be a member of all listed groups in order to be authorized.